### PR TITLE
Develop

### DIFF
--- a/classes/minion/task/db/generate.php
+++ b/classes/minion/task/db/generate.php
@@ -46,9 +46,9 @@ class Minion_Task_Db_Generate extends Minion_Task
 	 */
 	public function execute(array $config)
 	{
-		if (empty($config['group']) OR empty($config['description']))
+		if (empty($config['group']))
 		{
-			return 'Please provide --group and --description'.PHP_EOL.
+			return 'Please provide --group'.PHP_EOL.
 			       'See help for more info'.PHP_EOL;
 		}
 

--- a/classes/minion/task/db/generate.php
+++ b/classes/minion/task/db/generate.php
@@ -65,6 +65,11 @@ class Minion_Task_Db_Generate extends Minion_Task
 			->set('description', $description)
 			->render();
 
+		if ( ! is_dir(dirname($file)))
+		{
+			mkdir(dirname($file), 0775, TRUE);
+		}
+
 		file_put_contents($file, $data);
 
 		return 'Migration generated in '.$file.PHP_EOL;

--- a/classes/minion/task/db/generate.php
+++ b/classes/minion/task/db/generate.php
@@ -51,7 +51,7 @@ class Minion_Task_Db_Generate extends Minion_Task
 			       'See help for more info'.PHP_EOL;
 		}
 
-		$group    = rtrim(realpath($config['group']), '/').'/';
+		$group    = $config['group'].'/';
 		$description = $config['description'];
 
 		// {year}{month}{day}{hour}{minute}{second}
@@ -79,9 +79,6 @@ class Minion_Task_Db_Generate extends Minion_Task
 	 */
 	protected function _generate_classname($group, $time)
 	{
-		// Chop up everything up until the relative path
-		$group = substr($group, strrpos($group, 'migrations/') + 11);
-
 		$class = ucwords(str_replace('/', ' ', $group));
 
 		// If group is empty then we want to avoid double underscore in the 
@@ -107,8 +104,7 @@ class Minion_Task_Db_Generate extends Minion_Task
 	public function _generate_filename($group, $time, $description)
 	{
 		$description = substr(strtolower($description), 0, 100);
-
-		return $group.$time.'_'.preg_replace('~[^a-z]+~', '-', $description).EXT;
+		return DOCROOT.Kohana::config('minion/migration')->default_path.$group.$time.'_'.preg_replace('~[^a-z]+~', '-', $description).EXT;
 	}
 
 }

--- a/classes/minion/task/db/generate.php
+++ b/classes/minion/task/db/generate.php
@@ -35,7 +35,8 @@ class Minion_Task_Db_Generate extends Minion_Task
 	 */
 	protected $_config = array(
 		'group',
-		'description'
+		'description',
+		'location'
 	);
 
 	/**
@@ -54,10 +55,16 @@ class Minion_Task_Db_Generate extends Minion_Task
 		$group    = $config['group'].'/';
 		$description = $config['description'];
 
+		if (empty($config['location']))
+		{
+			$config['location'] = APPPATH;
+		}
+		$location = rtrim(realpath($config['location']), '/').'/migrations/';
+
 		// {year}{month}{day}{hour}{minute}{second}
 		$time  = date('YmdHis');
 		$class = $this->_generate_classname($group, $time);
-		$file  = $this->_generate_filename($group, $time, $description);
+		$file  = $this->_generate_filename($location, $group, $time, $description);
 
 
 		$data = Kohana::FILE_SECURITY.View::factory('minion/task/db/generate/template')
@@ -106,10 +113,10 @@ class Minion_Task_Db_Generate extends Minion_Task
 	 * @param  string Description
 	 * @return string Filename
 	 */
-	public function _generate_filename($group, $time, $description)
+	public function _generate_filename($location, $group, $time, $description)
 	{
 		$description = substr(strtolower($description), 0, 100);
-		return DOCROOT.Kohana::config('minion/migration')->default_path.$group.$time.'_'.preg_replace('~[^a-z]+~', '-', $description).EXT;
+		return $location.$group.$time.'_'.preg_replace('~[^a-z]+~', '-', $description).EXT;
 	}
 
 }

--- a/config/minion/migration.php
+++ b/config/minion/migration.php
@@ -6,6 +6,9 @@ return array(
 	'group_connection' => array(
 		
 	),
+
+	'default_path' => 'migrations/',
+
 	/**
 	 * This specifies which migration should be the "base", in timestamp form.
 	 * This migration will not be run when --migrate-down is called

--- a/config/minion/migration.php
+++ b/config/minion/migration.php
@@ -7,8 +7,6 @@ return array(
 		
 	),
 
-	'default_path' => 'application/migrations/',
-
 	/**
 	 * This specifies which migration should be the "base", in timestamp form.
 	 * This migration will not be run when --migrate-down is called

--- a/config/minion/migration.php
+++ b/config/minion/migration.php
@@ -7,7 +7,7 @@ return array(
 		
 	),
 
-	'default_path' => 'migrations/',
+	'default_path' => 'application/migrations/',
 
 	/**
 	 * This specifies which migration should be the "base", in timestamp form.

--- a/views/minion/task/db/generate/template.php
+++ b/views/minion/task/db/generate/template.php
@@ -1,8 +1,8 @@
-
-
+<?php if(!empty($description)): ?>
 /**
  * <?php echo $description.PHP_EOL; ?>
  */
+<?php endif; ?>
 class <?php echo $class; ?> extends Minion_Migration_Base {
 
 	/**


### PR DESCRIPTION
Yes, it's an API breakage, but considering there's no viable documentation, it shouldn't be much of a problem.

First commit changes the way script is handling --group during db:generate. It treats it now like a group instead of expecting full location. Considering that probably no one will have more than one directory for migrations in project, I've also added configuration field for default path (it's necessary if index.php is not in the same directory as APPPATH/SYSPATH) I'll leave implementing --location to you because I simply don't need it.

I also believe automatic creation of directories would be useful because it's much easier to bootstrap and create new groups now.
