### PR TITLE
Mod/db migrate

### DIFF
--- a/classes/minion/task/db/generate.php
+++ b/classes/minion/task/db/generate.php
@@ -58,7 +58,7 @@ class Minion_Task_Db_Generate extends Minion_Task
 
 	}
 	
-	public function generate($config)
+	public function generate($config, $up = null, $down = null)
 	{
 		$defaults = array(
 			'location'    => APPPATH,
@@ -89,6 +89,8 @@ class Minion_Task_Db_Generate extends Minion_Task
 		$data = Kohana::FILE_SECURITY.View::factory('minion/task/db/generate/template')
 			->set('class', $class)
 			->set('description', $description)
+			->set('up', $up)
+			->set('down', $down)
 			->render();
 
 		if ( ! is_dir(dirname($file)))

--- a/classes/minion/task/db/generate.php
+++ b/classes/minion/task/db/generate.php
@@ -46,6 +46,20 @@ class Minion_Task_Db_Generate extends Minion_Task
 	 */
 	public function execute(array $config)
 	{
+		try
+		{
+			$file = $this->generate($config);
+			Minion_CLI::write('Migration generated: '.$file);	
+		}
+		catch(ErrorException $e)
+		{
+			Minion_CLI::write($e->getMessage());
+		}
+
+	}
+	
+	public function generate($config)
+	{
 		$defaults = array(
 			'location'    => APPPATH,
 			'description' => '',
@@ -59,9 +73,7 @@ class Minion_Task_Db_Generate extends Minion_Task
 
 		if ( ! $this->_valid_group($config['group']))
 		{
-			Minion_CLI::write('Please provide a valid --group');
-			Minion_CLI::write('See help for more info');
-			return;
+			throw new ErrorException("Please provide a valid --group\nSee help for more info");
 		}
 
 		$group = $config['group'].'/';
@@ -86,8 +98,7 @@ class Minion_Task_Db_Generate extends Minion_Task
 
 		file_put_contents($file, $data);
 
-		Minion_CLI::write('Migration generated: '.$file);
-		return;
+		return $file;
 	}
 
 	/**

--- a/views/minion/task/db/generate/template.php
+++ b/views/minion/task/db/generate/template.php
@@ -12,7 +12,12 @@ class <?php echo $class; ?> extends Minion_Migration_Base {
 	 */
 	public function up(Kohana_Database $db)
 	{
+<?php if(!empty($up)): ?>
+<?php echo $up; ?>
+
+<?php else: ?>
 		// $db->query(NULL, 'CREATE TABLE ... ');
+<?php endif; ?>
 	}
 
 	/**
@@ -22,6 +27,11 @@ class <?php echo $class; ?> extends Minion_Migration_Base {
 	 */
 	public function down(Kohana_Database $db)
 	{
+<?php if(!empty($down)): ?>
+<?php echo $down; ?>
+
+<?php else: ?>
 		// $db->query(NULL, 'DROP TABLE ... ');
+<?php endif; ?>
 	}
 }


### PR DESCRIPTION
This pull request adds ability for tasks-migration to be useful for other tasks (for example autogeneration of migrations) by providing public method to generate fresh migration.

I won't hide I need this for my scaffolder and I don't see the need to rewrite whole migrations module just for this one thing. Change won't break any existing API and may be useful for other people.
