### PR TITLE
Changed minion_migrations table to use utf-8 rather than latin1

### DIFF
--- a/minion_schema.sql
+++ b/minion_schema.sql
@@ -5,4 +5,4 @@ CREATE TABLE `minion_migrations` (
   `applied` tinyint(1) DEFAULT '0',
   PRIMARY KEY (`timestamp`,`group`),
   UNIQUE KEY `MIGRATION_ID` (`timestamp`,`description`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Right now schema uses latin1 which is evil and should be avoided.
