### PR TITLE
Template coding standards corrections

### DIFF
--- a/classes/minion/task/migrations/new.php
+++ b/classes/minion/task/migrations/new.php
@@ -87,7 +87,8 @@ class Minion_Task_Migrations_New extends Minion_Task
 		$file = $this->_generate_filename($location, $group, $time, $description);
 
 
-		$data = Kohana::FILE_SECURITY.View::factory('minion/task/migrations/new/template')
+		$data = Kohana::FILE_SECURITY.PHP_EOL.
+		View::factory('minion/task/migrations/new/template')
 			->set('class', $class)
 			->set('description', $description)
 			->set('up', $up)

--- a/views/minion/task/migrations/new/template.php
+++ b/views/minion/task/migrations/new/template.php
@@ -1,3 +1,4 @@
+
 <?php if(!empty($description)): ?>
 /**
  * <?php echo $description.PHP_EOL; ?>
@@ -8,7 +9,7 @@ class <?php echo $class; ?> extends Minion_Migration_Base {
 	/**
 	 * Run queries needed to apply this migration
 	 *
-	 * @param Kohana_Database Database connection
+	 * @param Kohana_Database $db Database connection
 	 */
 	public function up(Kohana_Database $db)
 	{
@@ -23,7 +24,7 @@ class <?php echo $class; ?> extends Minion_Migration_Base {
 	/**
 	 * Run queries needed to remove this migration
 	 *
-	 * @param Kohana_Database Database connection
+	 * @param Kohana_Database $db Database connection
 	 */
 	public function down(Kohana_Database $db)
 	{


### PR DESCRIPTION
- The Kohana PHP security line now properly has a newline at the end of it
- The new migration template view now also contains a newline at the begining so that classes and the PHP opening line aren't all smushed together
- Added the parameter name to the @param tag so phpcs stops complaining

This will require conflict resolution with pull request #33
