### PR TITLE
Add a configuration option for the table name

### DIFF
--- a/classes/Model/Minion/Migration.php
+++ b/classes/Model/Minion/Migration.php
@@ -15,7 +15,7 @@ class Model_Minion_Migration extends Model
 	 * The table that's used to store the migrations
 	 * @var string
 	 */
-	protected $_table = 'minion_migrations';
+	protected $_table;
 
 	/**
 	 * Constructs the model, taking a Database connection as the first and only
@@ -26,6 +26,8 @@ class Model_Minion_Migration extends Model
 	public function __construct(Kohana_Database $db)
 	{
 		$this->_db = $db;
+
+		$this->_table = Kohana::$config->load('minion/migration.table');
 	}
 
 	/**
@@ -170,7 +172,9 @@ class Model_Minion_Migration extends Model
 
 		if ( ! count($query))
 		{
-			$sql = file_get_contents(Kohana::find_file('', 'minion_schema', 'sql'));
+			$sql = View::factory('minion/task/migrations/schema')
+				->set('table_name', $this->_table)
+				->render();
 
 			$this->_db->query(NULL, $sql);
 		}

--- a/config/minion/migration.php
+++ b/config/minion/migration.php
@@ -8,6 +8,11 @@ return array(
 	),
 
 	/**
+	 * The table used to store migrations
+	 */
+	'table' => 'minion_migrations',
+
+	/**
 	 * This specifies which migration should be the "base", in timestamp form.
 	 * This migration will not be run when --migrate-down is called
 	 * 

--- a/minion_schema.sql
+++ b/minion_schema.sql
@@ -1,8 +1,0 @@
-CREATE TABLE `minion_migrations` (
-  `timestamp` varchar(14) NOT NULL,
-  `description` varchar(100) NOT NULL,
-  `group` varchar(100) NOT NULL,
-  `applied` tinyint(1) DEFAULT '0',
-  PRIMARY KEY (`timestamp`,`group`),
-  UNIQUE KEY `MIGRATION_ID` (`timestamp`,`description`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/views/minion/task/migrations/schema.php
+++ b/views/minion/task/migrations/schema.php
@@ -1,0 +1,8 @@
+CREATE TABLE `<? echo $table_name; ?>` (
+	`timestamp` varchar(14) NOT NULL,
+	`description` varchar(100) NOT NULL,
+	`group` varchar(100) NOT NULL,
+	`applied` tinyint(1) DEFAULT '0',
+	PRIMARY KEY (`timestamp`,`group`),
+	UNIQUE KEY `MIGRATION_ID` (`timestamp`,`description`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;


### PR DESCRIPTION
This allows the name of the table that the migrations are stored in to be customized in the configuration file using the `table` key.
