### PR TITLE
use table_prefix from database config when creating migrations table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Icon?
 nbproject
 Thumbs.db
 *.komodoproject
+.idea

--- a/classes/Model/Minion/Migration.php
+++ b/classes/Model/Minion/Migration.php
@@ -172,7 +172,7 @@ class Model_Minion_Migration extends Model
 		if ( ! count($query))
 		{
 			$sql = View::factory('minion/task/migrations/schema')
-				->set('table_name', $this->_table)
+				->set('table_name', $this->_db->table_prefix() . $this->_table)
 				->render();
 
 			$this->_db->query(NULL, $sql);

--- a/classes/Model/Minion/Migration.php
+++ b/classes/Model/Minion/Migration.php
@@ -167,12 +167,13 @@ class Model_Minion_Migration extends Model
 	 */
 	public function ensure_table_exists()
 	{
-		$query = $this->_db->query(Database::SELECT, "SHOW TABLES like '".$this->_table."'");
+        $table = $this->_db->table_prefix() . $this->_table;
+		$query = $this->_db->query(Database::SELECT, "SHOW TABLES like '".$table."'");
 
 		if ( ! count($query))
 		{
 			$sql = View::factory('minion/task/migrations/schema')
-				->set('table_name', $this->_db->table_prefix() . $this->_table)
+				->set('table_name', $table)
 				->render();
 
 			$this->_db->query(NULL, $sql);


### PR DESCRIPTION
When migrations table is created, it uses table name from migration.php config file.
If we have table_prefix in database config (it is used by Database module to create full table names when preforming queries) it affects queries preformed in tasks-migrations module also, but the migrations table was created without prefix, so the table doesn't exists error is thrown. 
The migrations table needs to be created also with the prefix.
